### PR TITLE
Update podspec to pass latest CocoaPods requirements

### DIFF
--- a/DZWebDAVClient.podspec
+++ b/DZWebDAVClient.podspec
@@ -2,11 +2,13 @@ Pod::Spec.new do |s|
   s.name         = 'DZWebDAVClient'
   s.license      = 'MIT'
   s.version      = '1.0.0'
-  s.summary      = 'An Objective-C WebDAV client based on AFNetworking'
+  s.summary      = 'An Objective-C WebDAV client based on AFNetworking.'
   s.homepage     = 'https://github.com/zwaldowski/DZWebDAVClient'
   s.author       = { 'Zachary Waldowski' => 'zwaldowski@gmail.com' }
-  s.source       = { :git => 'https://github.com/zwaldowski/DZWebDAVClient.git', :branch => 'master' }
+  s.source       = { :git => 'https://github.com/zwaldowski/DZWebDAVClient.git', :tag => '1.0.0' }
   s.source_files = 'DZWebDAVClient/*.{h,m}'
   s.requires_arc = true
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
   s.dependency     'AFNetworking'
 end


### PR DESCRIPTION
- Add punctuation mark
- Add git repo tag (note: you’ll need to actually tag the repository `1.0.0`)
- Add platforms requirements
